### PR TITLE
Revert "chore(deps): update helm chart redis to v14"

### DIFF
--- a/kube-system/authelia/authelia-redis.yaml
+++ b/kube-system/authelia/authelia-redis.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       # renovate: registryUrl=https://charts.bitnami.com/bitnami
       chart: redis
-      version: 14.0.2
+      version: 13.0.1
       sourceRef:
         kind: HelmRepository
         name: bitnami-charts


### PR DESCRIPTION
Reverts WRMilling/k3s-gitops#85

Minor upgrade issue that prevents the helm upgrade. Going to take a look at this when I solve redis ACL issues for the Authelia issue #52 